### PR TITLE
Adjust icon tokens to add background block and adjust content disabled

### DIFF
--- a/src/components/icon.ts
+++ b/src/components/icon.ts
@@ -5,7 +5,14 @@ const icon = {
     content: {
       color: {
         regular: palette.blue.B400,
-        disabled: palette.neutral.N20,
+        disabled: palette.neutral.N70,
+        hover: palette.blue.B300,
+      },
+    },
+    background: {
+      color: {
+        regular: palette.blue.B400,
+        disabled: palette.neutral.N70,
         hover: palette.blue.B300,
       },
     },
@@ -21,7 +28,14 @@ const icon = {
     content: {
       color: {
         regular: palette.green.G400,
-        disabled: palette.neutral.N20,
+        disabled: palette.neutral.N70,
+        hover: palette.green.G300,
+      },
+    },
+    background: {
+      color: {
+        regular: palette.green.G400,
+        disabled: palette.neutral.N70,
         hover: palette.green.G300,
       },
     },
@@ -37,7 +51,14 @@ const icon = {
     content: {
       color: {
         regular: palette.yellow.Y400,
-        disabled: palette.neutral.N20,
+        disabled: palette.neutral.N70,
+        hover: palette.yellow.Y300,
+      },
+    },
+    background: {
+      color: {
+        regular: palette.yellow.Y400,
+        disabled: palette.neutral.N70,
         hover: palette.yellow.Y300,
       },
     },
@@ -53,7 +74,14 @@ const icon = {
     content: {
       color: {
         regular: palette.red.R400,
-        disabled: palette.neutral.N20,
+        disabled: palette.neutral.N70,
+        hover: palette.red.R300,
+      },
+    },
+    background: {
+      color: {
+        regular: palette.red.R400,
+        disabled: palette.neutral.N70,
         hover: palette.red.R300,
       },
     },
@@ -69,7 +97,14 @@ const icon = {
     content: {
       color: {
         regular: palette.purple.P400,
-        disabled: palette.neutral.N20,
+        disabled: palette.neutral.N70,
+        hover: palette.purple.P300,
+      },
+    },
+    background: {
+      color: {
+        regular: palette.purple.P400,
+        disabled: palette.neutral.N70,
         hover: palette.purple.P300,
       },
     },
@@ -85,7 +120,14 @@ const icon = {
     content: {
       color: {
         regular: palette.neutral.N900,
-        disabled: palette.neutral.N20,
+        disabled: palette.neutral.N70,
+        hover: palette.neutral.N500,
+      },
+    },
+    background: {
+      color: {
+        regular: palette.neutral.N900,
+        disabled: palette.neutral.N70,
         hover: palette.neutral.N500,
       },
     },
@@ -100,9 +142,16 @@ const icon = {
   gray: {
     content: {
       color: {
-        regular: palette.neutral.N20,
-        disabled: palette.neutral.N20,
-        hover: palette.neutral.N30,
+        regular: palette.neutral.N300,
+        disabled: palette.neutral.N70,
+        hover: palette.neutral.N100,
+      },
+    },
+    background: {
+      color: {
+        regular: palette.neutral.N300,
+        disabled: palette.neutral.N70,
+        hover: palette.neutral.N100,
       },
     },
     contrast: {
@@ -117,7 +166,14 @@ const icon = {
     content: {
       color: {
         regular: palette.neutral.N10,
-        disabled: palette.neutral.N20,
+        disabled: palette.neutral.N70,
+        hover: palette.neutral.N0,
+      },
+    },
+    background: {
+      color: {
+        regular: palette.neutral.N10,
+        disabled: palette.neutral.N70,
         hover: palette.neutral.N0,
       },
     },

--- a/src/components/icon.ts
+++ b/src/components/icon.ts
@@ -12,7 +12,7 @@ const icon = {
     background: {
       color: {
         regular: palette.blue.B400,
-        disabled: palette.neutral.N70,
+        disabled: palette.neutral.N20,
         hover: palette.blue.B300,
       },
     },
@@ -35,7 +35,7 @@ const icon = {
     background: {
       color: {
         regular: palette.green.G400,
-        disabled: palette.neutral.N70,
+        disabled: palette.neutral.N20,
         hover: palette.green.G300,
       },
     },
@@ -58,7 +58,7 @@ const icon = {
     background: {
       color: {
         regular: palette.yellow.Y400,
-        disabled: palette.neutral.N70,
+        disabled: palette.neutral.N20,
         hover: palette.yellow.Y300,
       },
     },
@@ -81,7 +81,7 @@ const icon = {
     background: {
       color: {
         regular: palette.red.R400,
-        disabled: palette.neutral.N70,
+        disabled: palette.neutral.N20,
         hover: palette.red.R300,
       },
     },
@@ -104,7 +104,7 @@ const icon = {
     background: {
       color: {
         regular: palette.purple.P400,
-        disabled: palette.neutral.N70,
+        disabled: palette.neutral.N20,
         hover: palette.purple.P300,
       },
     },
@@ -127,7 +127,7 @@ const icon = {
     background: {
       color: {
         regular: palette.neutral.N900,
-        disabled: palette.neutral.N70,
+        disabled: palette.neutral.N20,
         hover: palette.neutral.N500,
       },
     },
@@ -150,7 +150,7 @@ const icon = {
     background: {
       color: {
         regular: palette.neutral.N300,
-        disabled: palette.neutral.N70,
+        disabled: palette.neutral.N20,
         hover: palette.neutral.N100,
       },
     },
@@ -173,7 +173,7 @@ const icon = {
     background: {
       color: {
         regular: palette.neutral.N10,
-        disabled: palette.neutral.N70,
+        disabled: palette.neutral.N20,
         hover: palette.neutral.N0,
       },
     },


### PR DESCRIPTION
I have made the requested modifications. Now each appearance has a background block that includes its three modifiers, and I have also updated the content-color-disabled token from n20 to n70 for all appearances.