### PR TITLE
Add gray appearance in spinner tokens

### DIFF
--- a/src/components/spinner.ts
+++ b/src/components/spinner.ts
@@ -109,6 +109,24 @@ const spinner = {
       },
     },
   },
+  gray: {
+    solid: {
+      spin: {
+        color: palette.neutral.N100,
+      },
+      track: {
+        color: palette.neutral.N30,
+      },
+    },
+    transparent: {
+      spin: {
+        color: palette.neutral.N100,
+      },
+      track: {
+        color: palette.neutralAlpha.N0A,
+      },
+    },
+  },
   light: {
     solid: {
       spin: {


### PR DESCRIPTION
This pull request introduces a significant enhancement to the spinner tokens within our application's design system by adding a 'gray' appearance option. Aimed at increasing the versatility and aesthetic alignment of our loading indicators across various backgrounds and contexts, this update enriches the spinner component with a more subdued and universally adaptable color option.