### PR TITLE
Update the reference token for the input component, in its focus state

### DIFF
--- a/src/components/input.ts
+++ b/src/components/input.ts
@@ -5,7 +5,7 @@ export const input = {
     color: {
       regular: palette.neutral.N40,
       disabled: palette.neutral.N40,
-      focus: palette.blue.B400,
+      focus: palette.blue.B300,
       invalid: palette.red.R400,
     },
   },

--- a/src/components/label.ts
+++ b/src/components/label.ts
@@ -6,7 +6,7 @@ export const label = {
       regular: palette.neutral.N900,
       disabled: palette.neutral.N70,
       focus: palette.blue.B300,
-      invalid: palette.red.R300,
+      invalid: palette.red.R400,
     },
   },
 };


### PR DESCRIPTION
Currently, the reference token for border focus has a value of B400, update the token to a value of B300. This is so that there is no color difference between the "label" and "input" components.